### PR TITLE
refactor: v2 API, config, N-sample EvoManager, AnnData helper, tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "scevonet"
-version = "2.0.0"
+version = "2.1.0"
 description = "Cell state and gene program networks from scRNA-seq (LightGBM / cross-dataset)"
 readme = "README.md"
 requires-python = ">=3.9"
@@ -23,7 +23,9 @@ dependencies = [
 
 [project.optional-dependencies]
 anndata = ["anndata>=0.8"]
+enrichment = ["gseapy>=1.0.5"]
 dev = ["pytest>=7", "pytest-cov>=4"]
+all = ["anndata>=0.8", "gseapy>=1.0.5"]
 
 [project.urls]
 Homepage = "https://github.com/Qotov/scEvoNet"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,36 @@
+[build-system]
+requires = ["setuptools>=61", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "scevonet"
+version = "2.0.0"
+description = "Cell state and gene program networks from scRNA-seq (LightGBM / cross-dataset)"
+readme = "README.md"
+requires-python = ">=3.9"
+license = { text = "MIT" }
+authors = [{ name = "Aleksandr Kotov", email = "alexander.o.kotov@gmail.com" }]
+dependencies = [
+    "lightgbm>=3.0.0",
+    "pandas>=1.3",
+    "numpy>=1.20",
+    "networkx>=2.5",
+    "scipy>=1.7",
+    "scikit-learn>=1.0",
+    "matplotlib>=3.4",
+    "seaborn>=0.11",
+]
+
+[project.optional-dependencies]
+anndata = ["anndata>=0.8"]
+dev = ["pytest>=7", "pytest-cov>=4"]
+
+[project.urls]
+Homepage = "https://github.com/Qotov/scEvoNet"
+
+[tool.setuptools.packages.find]
+include = ["scevonet*"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+python_files = ["test_*.py"]

--- a/scevonet/__init__.py
+++ b/scevonet/__init__.py
@@ -1,0 +1,14 @@
+"""scEvoNet: gradient boosting-based cell state evolution and gene–cell networks."""
+
+from scevonet.adata import sample_from_adata
+from scevonet.net import EvoManager, Sample, SampleConfig, draw_net
+
+__all__ = [
+    "EvoManager",
+    "Sample",
+    "SampleConfig",
+    "draw_net",
+    "sample_from_adata",
+    "__version__",
+]
+__version__ = "2.0.0"

--- a/scevonet/__init__.py
+++ b/scevonet/__init__.py
@@ -1,14 +1,33 @@
 """scEvoNet: gradient boosting-based cell state evolution and gene–cell networks."""
 
 from scevonet.adata import sample_from_adata
-from scevonet.net import EvoManager, Sample, SampleConfig, draw_net
+from scevonet.net import EvoManager, Sample, SampleConfig, draw_net, fit_ovr_model
+from scevonet.programs import (
+    classify_transition_genes,
+    cluster_mean_expression,
+    enrich_by_cell_type_programs,
+    enrich_genes,
+)
+from scevonet.validation import (
+    bootstrap_importance_stability,
+    leave_batch_out_auc,
+    permutation_importance_null,
+)
 
 __all__ = [
     "EvoManager",
     "Sample",
     "SampleConfig",
     "draw_net",
+    "fit_ovr_model",
     "sample_from_adata",
+    "cluster_mean_expression",
+    "classify_transition_genes",
+    "enrich_genes",
+    "enrich_by_cell_type_programs",
+    "bootstrap_importance_stability",
+    "permutation_importance_null",
+    "leave_batch_out_auc",
     "__version__",
 ]
-__version__ = "2.0.0"
+__version__ = "2.1.0"

--- a/scevonet/adata.py
+++ b/scevonet/adata.py
@@ -1,0 +1,51 @@
+"""Optional helpers for ``AnnData`` / Scanpy workflows."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pandas as pd
+
+from scevonet.net import Sample
+
+if TYPE_CHECKING:
+    from anndata import AnnData
+
+
+def sample_from_adata(
+    adata: AnnData,
+    cluster_key: str,
+    *,
+    layer: str | None = None,
+    gene_symbols: str | None = None,
+) -> Sample:
+    """
+    Build a :class:`Sample` from an ``AnnData`` object (e.g. after Scanpy preprocessing).
+
+    Parameters
+    ----------
+    adata
+        Annotated matrix; expression in ``X`` or ``layers[layer]``.
+    cluster_key
+        ``adata.obs`` column with cell type / cluster labels.
+    layer
+        If set, use ``adata.layers[layer]`` instead of ``X``.
+    gene_symbols
+        If set, use ``adata.var[gene_symbols]`` as column names; otherwise ``var_names``.
+    """
+    try:
+        import anndata  # noqa: F401
+    except ImportError as e:
+        raise ImportError("sample_from_adata requires the 'anndata' package.") from e
+
+    X = adata.layers[layer] if layer is not None else adata.X
+    if hasattr(X, "toarray"):
+        X = X.toarray()
+    genes = (
+        adata.var[gene_symbols].astype(str).values
+        if gene_symbols is not None
+        else adata.var_names.astype(str).values
+    )
+    matrix = pd.DataFrame(X, index=adata.obs_names.astype(str), columns=genes)
+    cell_types = adata.obs[cluster_key].astype(str).tolist()
+    return Sample(matrix, cell_types)

--- a/scevonet/net.py
+++ b/scevonet/net.py
@@ -47,6 +47,74 @@ class SampleConfig:
     early_stopping_rounds: int = 10
 
 
+def fit_ovr_model(
+    matrix: pd.DataFrame,
+    y_binary: pd.Series,
+    config: SampleConfig | None = None,
+) -> dict[str, Any]:
+    """
+    Train a single one-vs-rest cell-type model using the same two-stage LightGBM
+    pipeline as :class:`Sample` (full genes → top-K → refined model).
+
+    Parameters
+    ----------
+    matrix
+        Expression matrix (cells × genes); index must match ``y_binary``.
+    y_binary
+        Binary target (1 = positive cell type, 0 = other), index aligned with ``matrix``.
+    """
+    cfg = config or SampleConfig()
+    if not y_binary.index.equals(matrix.index):
+        raise ValueError("y_binary index must match matrix.index")
+    LGBMRegressor = _lgbm_regressor()
+    x_train, x_test, y_train, y_test = train_test_split(
+        matrix,
+        y_binary,
+        test_size=cfg.test_size,
+        random_state=cfg.random_state,
+    )
+    model = LGBMRegressor(
+        n_estimators=cfg.n_estimators,
+        random_state=cfg.random_state,
+        verbose=-1,
+    )
+    model.fit(
+        x_train,
+        y_train,
+        eval_set=[(x_test, y_test)],
+        eval_metric="auc",
+        early_stopping_rounds=cfg.early_stopping_rounds,
+        verbose=False,
+    )
+    top_features = (
+        pd.DataFrame({"gene": x_train.columns, "importance": model.feature_importances_})
+        .sort_values("importance", ascending=False)
+        .reset_index(drop=True)
+    )
+    genes = list(top_features["gene"][: cfg.top_features_limit])
+    x_train_upd = sigmoid(update_df(x_train, genes))
+    x_test_upd = sigmoid(update_df(x_test, genes))
+    model_upd = LGBMRegressor(
+        n_estimators=cfg.n_estimators,
+        random_state=cfg.random_state,
+        verbose=-1,
+    )
+    model_upd.fit(
+        x_train_upd,
+        y_train,
+        eval_set=[(x_test_upd, y_test)],
+        eval_metric="auc",
+        early_stopping_rounds=cfg.early_stopping_rounds,
+        verbose=False,
+    )
+    top_features_upd = (
+        pd.DataFrame({"gene": x_train_upd.columns, "importance": model_upd.feature_importances_})
+        .sort_values("importance", ascending=False)
+        .reset_index(drop=True)
+    )
+    return {"model": model_upd, "features": top_features_upd}
+
+
 class Sample:
     """Fit one LGBM regressor per cell type (1 vs rest), with top-feature refinement."""
 
@@ -73,56 +141,7 @@ class Sample:
             self.cell_types_df[cell_type] = states
 
     def _generate_model(self, cluster_col: pd.Series) -> dict:
-        LGBMRegressor = _lgbm_regressor()
-        cfg = self.config
-        x_train, x_test, y_train, y_test = train_test_split(
-            self.matrix,
-            cluster_col,
-            test_size=cfg.test_size,
-            random_state=cfg.random_state,
-        )
-        model = LGBMRegressor(
-            n_estimators=cfg.n_estimators,
-            random_state=cfg.random_state,
-            verbose=-1,
-        )
-        model.fit(
-            x_train,
-            y_train,
-            eval_set=[(x_test, y_test)],
-            eval_metric="auc",
-            early_stopping_rounds=cfg.early_stopping_rounds,
-            verbose=False,
-        )
-        top_features = (
-            pd.DataFrame({"gene": x_train.columns, "importance": model.feature_importances_})
-            .sort_values("importance", ascending=False)
-            .reset_index(drop=True)
-        )
-        genes = list(top_features["gene"][: cfg.top_features_limit])
-        x_train_upd = sigmoid(update_df(x_train, genes))
-        x_test_upd = sigmoid(update_df(x_test, genes))
-        model_upd = LGBMRegressor(
-            n_estimators=cfg.n_estimators,
-            random_state=cfg.random_state,
-            verbose=-1,
-        )
-        model_upd.fit(
-            x_train_upd,
-            y_train,
-            eval_set=[(x_test_upd, y_test)],
-            eval_metric="auc",
-            early_stopping_rounds=cfg.early_stopping_rounds,
-            verbose=False,
-        )
-        top_features_upd = (
-            pd.DataFrame(
-                {"gene": x_train_upd.columns, "importance": model_upd.feature_importances_}
-            )
-            .sort_values("importance", ascending=False)
-            .reset_index(drop=True)
-        )
-        return {"model": model_upd, "features": top_features_upd}
+        return fit_ovr_model(self.matrix, cluster_col, self.config)
 
     def _get_all_models(self) -> None:
         for cell_type in self.cell_types_df.columns:

--- a/scevonet/net.py
+++ b/scevonet/net.py
@@ -1,288 +1,380 @@
-from lightgbm import LGBMRegressor, LGBMClassifier, LGBMRanker
-from sklearn.model_selection import train_test_split
-import pandas as pd
-import networkx as nx
-from .utils import *
-from scipy.stats import zscore
-import matplotlib.pyplot as plt
-import seaborn as sns
+"""LGBM-based cell-type models, cross-dataset predictions, and gene–cell networks."""
 
-logging.basicConfig(level=logging.INFO)
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+import matplotlib
+import matplotlib.pyplot as plt
+import numpy as np
+import networkx as nx
+import pandas as pd
+import seaborn as sns
+from scipy.stats import zscore
+from sklearn.model_selection import train_test_split
+
+from scevonet.utils import sigmoid, update_df
+
+logger = logging.getLogger(__name__)
+
+
+def _show_or_close(fig=None) -> None:
+    """``plt.show()`` in interactive backends; close figure when running headless (e.g. Agg)."""
+    be = matplotlib.get_backend().lower()
+    if be in ("agg", "cairo", "pdf", "ps", "svg", "template"):
+        plt.close(fig if fig is not None else plt.gcf())
+    else:
+        plt.show()
+
+
+def _lgbm_regressor():
+    """Import LightGBM only when training (allows importing the package without libomp)."""
+    from lightgbm import LGBMRegressor
+
+    return LGBMRegressor
+
+
+@dataclass
+class SampleConfig:
+    """Training hyperparameters for one-vs-rest cell-type models."""
+
+    top_features_limit: int = 3000
+    n_estimators: int = 500
+    test_size: float = 0.25
+    random_state: int = 42
+    early_stopping_rounds: int = 10
 
 
 class Sample:
-    TOP_FEATURES_LIMIT = 3000
-    N_ESTIMATORS = 500
-    TEST_SIZE = 0.25
+    """Fit one LGBM regressor per cell type (1 vs rest), with top-feature refinement."""
 
-    def __init__(self, matrix, cell_types):
-        self.models = {}
+    def __init__(
+        self,
+        matrix: pd.DataFrame,
+        cell_types: list | pd.Series,
+        config: SampleConfig | None = None,
+    ):
+        self.config = config or SampleConfig()
+        self.models: dict[str, Any] = {}
         self.matrix = matrix
         self.cell_types = list(cell_types)
         self.cell_types_df = pd.DataFrame()
-        self.models_top_features = {}
+        self.models_top_features: dict[str, pd.DataFrame] = {}
 
-        self.generate_ys()
-        self.get_all_models()
+        self._generate_ys()
+        self._get_all_models()
 
-    def generate_ys(self):
-        """
-        Modifies list of N cell states into N lists of 1/0 state for each cell
-        """
-        for cell_type1 in list(set(self.cell_types)):
-            states = []
-            for cell_type2 in self.cell_types:
-                if cell_type2 == cell_type1:
-                    states.append(1)
-                else:
-                    states.append(0)
-            self.cell_types_df[cell_type1] = states
+    def _generate_ys(self) -> None:
+        """Encode each cell type as a binary 1/0 target across cells."""
+        for cell_type in sorted(set(self.cell_types)):
+            states = [1 if ct == cell_type else 0 for ct in self.cell_types]
+            self.cell_types_df[cell_type] = states
 
-    def generate_model(self, cluster_col):
-        """
-        Generates Light GBM model for a given Y
-        """
-        x_train, x_test, \
-            y_train, y_test = train_test_split(self.matrix, cluster_col, test_size=self.TEST_SIZE, random_state=42)
-        model = LGBMRegressor(n_estimators=self.N_ESTIMATORS, first_metric_only=True)
-        model.fit(x_train, y_train,
-                  eval_set=[(x_test, y_test)],
-                  eval_metric=['auc'],
-                  early_stopping_rounds=10,
-                  verbose=0)
-        top_features = pd.DataFrame([x_train.columns, model.feature_importances_]).T.sort_values(
-            1, ascending=False)
-        x_train_upd = sigmoid(update_df(x_train, list(top_features[0][:self.TOP_FEATURES_LIMIT])))
-        x_test_upd = sigmoid(update_df(x_test, list(top_features[0][:self.TOP_FEATURES_LIMIT])))
-        model_upd = LGBMRegressor(n_estimators=self.N_ESTIMATORS, first_metric_only=True)
-        model_upd.fit(x_train_upd, y_train,
-                      eval_set=[(x_test_upd, y_test)],
-                      eval_metric=['auc'],
-                      early_stopping_rounds=10,
-                      verbose=0)
-        top_features_upd = pd.DataFrame([x_train_upd.columns, model_upd.feature_importances_]).T.sort_values(
-            1, ascending=False)
-        return {
-            'model': model_upd,
-            'features': top_features_upd,
-        }
+    def _generate_model(self, cluster_col: pd.Series) -> dict:
+        LGBMRegressor = _lgbm_regressor()
+        cfg = self.config
+        x_train, x_test, y_train, y_test = train_test_split(
+            self.matrix,
+            cluster_col,
+            test_size=cfg.test_size,
+            random_state=cfg.random_state,
+        )
+        model = LGBMRegressor(
+            n_estimators=cfg.n_estimators,
+            random_state=cfg.random_state,
+            verbose=-1,
+        )
+        model.fit(
+            x_train,
+            y_train,
+            eval_set=[(x_test, y_test)],
+            eval_metric="auc",
+            early_stopping_rounds=cfg.early_stopping_rounds,
+            verbose=False,
+        )
+        top_features = (
+            pd.DataFrame({"gene": x_train.columns, "importance": model.feature_importances_})
+            .sort_values("importance", ascending=False)
+            .reset_index(drop=True)
+        )
+        genes = list(top_features["gene"][: cfg.top_features_limit])
+        x_train_upd = sigmoid(update_df(x_train, genes))
+        x_test_upd = sigmoid(update_df(x_test, genes))
+        model_upd = LGBMRegressor(
+            n_estimators=cfg.n_estimators,
+            random_state=cfg.random_state,
+            verbose=-1,
+        )
+        model_upd.fit(
+            x_train_upd,
+            y_train,
+            eval_set=[(x_test_upd, y_test)],
+            eval_metric="auc",
+            early_stopping_rounds=cfg.early_stopping_rounds,
+            verbose=False,
+        )
+        top_features_upd = (
+            pd.DataFrame(
+                {"gene": x_train_upd.columns, "importance": model_upd.feature_importances_}
+            )
+            .sort_values("importance", ascending=False)
+            .reset_index(drop=True)
+        )
+        return {"model": model_upd, "features": top_features_upd}
 
-    def get_all_models(self):
-        """
-        Writes generated models into Sample attributes
-        """
-        for cell_type_ in self.cell_types_df.columns:
-            model = self.generate_model(self.cell_types_df[cell_type_])
-            self.models[cell_type_] = model['model']
-            self.models_top_features[cell_type_] = model['features']
-            logging.info(f'Model for {cell_type_} is generated')
+    def _get_all_models(self) -> None:
+        for cell_type in self.cell_types_df.columns:
+            result = self._generate_model(self.cell_types_df[cell_type])
+            self.models[cell_type] = result["model"]
+            self.models_top_features[cell_type] = result["features"]
+            logger.info("Model for %s is trained", cell_type)
 
 
 class EvoManager:
-    def __init__(self, *args):
-        self.samples = dict(zip(list(range(len(args))), args))
-        self.predictions = dict()
-        self.run_predictions()
-        self.network = self.get_merged_network()
-        self.cell_types_similarity = self.generate_comparison_df()
+    """Cross-predict between datasets, merge gene–cell edges, and similarity matrices."""
+
+    def __init__(
+        self,
+        *samples: Sample,
+        network_top_genes: int = 75,
+        filter_krt_genes: bool = True,
+    ):
+        self.samples = dict(enumerate(samples))
+        self.network_top_genes = network_top_genes
+        self.filter_krt_genes = filter_krt_genes
+        self.predictions: dict[str, pd.DataFrame] = {}
+        self._run_predictions()
+        self.network = self._get_merged_network()
+        self.cell_types_similarity = self._generate_comparison_df()
 
     @staticmethod
-    def prepare_input_df(matrix, top_features, c=0):
-        """
-        Replaces missing genes with NaN values
-        """
-        df = pd.DataFrame()
-        for i in top_features:
-            if i in matrix.columns:
-                df[i] = list(matrix[i])
+    def prepare_input_df(matrix: pd.DataFrame, top_features: list[str]) -> pd.DataFrame:
+        """Align prediction matrix to training features; missing genes become NaN, then sigmoid."""
+        n_rows = matrix.shape[0]
+        data: dict[str, np.ndarray] = {}
+        for gene in top_features:
+            if gene in matrix.columns:
+                data[gene] = np.asarray(matrix[gene].values, dtype=np.float64)
             else:
-                # c += 1
-                df[i] = [float('NaN')] * matrix.shape[0]
-        # logging.info(f'C score is {c}')
+                data[gene] = np.full(n_rows, np.nan, dtype=np.float64)
+        df = pd.DataFrame(data, index=matrix.index)
         return sigmoid(df)
 
     @staticmethod
-    def get_means(df):
-        """
-        Returns mean score for each cell state
-        """
-        df_ = pd.DataFrame()
-        for i in [x for x in df.columns if 'cluster' not in x]:
-            df_[i] = list(df.groupby('clusters', as_index=False)[i].mean()[i])
-        df_.index = list(df.groupby('clusters', as_index=False)[i].mean()['clusters'])
-        return df_
+    def get_means(df: pd.DataFrame) -> pd.DataFrame:
+        """Mean predicted score per annotated cluster."""
+        model_cols = [c for c in df.columns if c != "clusters"]
+        out = df.groupby("clusters", as_index=True)[model_cols].mean()
+        return out
 
-    def between_two(self, sample1, sample2):
-        """
-        Runs all the models of the sample 1 on the sample2
-        """
-        df = pd.DataFrame()
-        df['clusters'] = sample2.cell_types
+    def between_two(self, sample1: Sample, sample2: Sample) -> pd.DataFrame:
+        """Apply all classifiers from ``sample1`` to cells in ``sample2``."""
+        df = pd.DataFrame({"clusters": sample2.cell_types})
         for cell_type_model in sample1.models:
-            top_features_ = list(
-                sample1.models_top_features[cell_type_model][0])
-            res = sample1.models[cell_type_model].predict(
-                self.prepare_input_df(sample2.matrix, top_features_))
-            df[cell_type_model] = res
+            feats = sample1.models_top_features[cell_type_model]["gene"].tolist()
+            mat = self.prepare_input_df(sample2.matrix, feats)
+            df[cell_type_model] = sample1.models[cell_type_model].predict(mat)
         return self.get_means(df)
 
-    def run_predictions(self):
-        """
-        Predicts cell states for each input sample
-        """
-        comment_ = 1
+    def _run_predictions(self) -> None:
+        n = len(self.samples)
+        total = n * n
+        done = 0
         for s1 in self.samples:
             for s2 in self.samples:
-                # if organism1!=organism2:
-                run_id = [s1, s2]
-                logging.info(f'Running {str(comment_)} out of 4')
-                comment_ += 1
-                self.predictions['_'.join([str(x) for x in run_id
-                                           ])] = self.between_two(
-                    self.samples[s1],
-                    self.samples[s2])
+                done += 1
+                key = f"{s1}_{s2}"
+                logger.info("Predictions %s / %s (%s)", done, total, key)
+                self.predictions[key] = self.between_two(self.samples[s1], self.samples[s2])
 
     @staticmethod
-    def extract_features(dct, krt_remove=True):
-        df = None
-        for cell_type_ in dct:
-            df_ = pd.DataFrame()
-            df_['Cell_type'] = [cell_type_] * 75
-            df_['Gene'] = list(dct[cell_type_][0])[:75]
-            df_['Importance'] = list(dct[cell_type_][1])[:75]
+    def extract_features(
+        dct: dict[str, pd.DataFrame],
+        top_n: int,
+        *,
+        krt_remove: bool = True,
+    ) -> pd.DataFrame:
+        """Flatten per-cell-type feature tables into long format for the bipartite network."""
+        parts: list[pd.DataFrame] = []
+        for cell_type_, feat_df in dct.items():
+            genes = feat_df["gene"].iloc[:top_n].tolist()
+            imp = feat_df["importance"].iloc[:top_n].tolist()
+            df_ = pd.DataFrame(
+                {
+                    "Cell_type": [cell_type_] * len(genes),
+                    "Gene": genes,
+                    "Importance": imp,
+                }
+            )
             if krt_remove:
-                df_ = df_[~df_.Gene.str.contains("KRT")]
-            if df is None:
-                df = df_
-            else:
-                df = pd.concat([df, df_])
-        return df
+                df_ = df_[~df_["Gene"].astype(str).str.contains("KRT", na=False)]
+            parts.append(df_)
+        return pd.concat(parts, ignore_index=True)
 
-    def get_merged_network(self):
-        """
-        Generates cell_state/gene_program network
-        """
-        return pd.concat([
-            self.extract_features(self.samples[x].models_top_features)
-            for x in self.samples
-        ])
+    def _get_merged_network(self) -> pd.DataFrame:
+        return pd.concat(
+            [
+                self.extract_features(
+                    self.samples[i].models_top_features,
+                    self.network_top_genes,
+                    krt_remove=self.filter_krt_genes,
+                )
+                for i in self.samples
+            ],
+            ignore_index=True,
+        )
 
     @staticmethod
-    def get_shortest_paths(network, in_, out_, k=10):
-        """
-        Generate K number of the shortest paths between selected nodes
-        """
-        x = nx.shortest_simple_paths(network, in_, out_)
-        for counter, path in enumerate(x):
+    def get_shortest_paths(
+        network: nx.Graph, source, target, k: int = 10
+    ):
+        """Yield up to ``k`` shortest simple paths between ``source`` and ``target``."""
+        paths = nx.shortest_simple_paths(network, source, target)
+        for counter, path in enumerate(paths):
             yield path
-            if counter == k - 1:
+            if counter >= k - 1:
                 break
 
-    def generate_comparison_df(self):
+    def _generate_comparison_df(self) -> pd.DataFrame:
         """
-        :return: confusion matrix for two samples
+        Similarity table used for clustermaps: z-scored predictions concatenated
+        as in the paper (train-on-i models evaluated on all j).
         """
-        return pd.concat([pd.concat([self.predictions['0_0'].apply(zscore),
-                                     self.predictions['0_1'].apply(zscore)]),
-                          pd.concat([self.predictions['1_0'].apply(zscore),
-                                     self.predictions['1_1'].apply(zscore)])], axis=1)
+        n = len(self.samples)
+        column_blocks: list[pd.DataFrame] = []
+        for train_idx in range(n):
+            row_parts = [self.predictions[f"{train_idx}_{j}"].apply(zscore) for j in range(n)]
+            column_blocks.append(pd.concat(row_parts, axis=0))
+        return pd.concat(column_blocks, axis=1)
 
-    def cluster_map(self, visible_legend=False, c_map="viridis"):
-        """
-        Draw a clustermap for df.T (clustering by "how cell types were predicted with all the models")
-        """
-        res = sns.clustermap(self.cell_types_similarity.T.corr(), cmap=c_map, yticklabels=True, figsize=(10, 10))
-        res.cax.set_visible(visible_legend)
-        plt.show()
+    def cluster_map(self, visible_legend: bool = False, c_map: str = "viridis") -> None:
+        """Clustermap of correlations between columns (cell-type model scores)."""
+        grid = sns.clustermap(
+            self.cell_types_similarity.T.corr(),
+            cmap=c_map,
+            yticklabels=True,
+            figsize=(10, 10),
+        )
+        grid.cax.set_visible(visible_legend)
+        _show_or_close(grid.figure)
 
-    def get_closest_cell_types(self, cell_type, type_='matrix'):
-        """
-        Returns sorted list of closest cell types
-        """
-        assert type_ in ['model', 'matrix']
-        if type_ == 'model':
+    def get_closest_cell_types(self, cell_type: str, type_: str = "matrix") -> list:
+        """Closest cell types by score column (``model``) or correlation (``matrix``)."""
+        if type_ not in ("model", "matrix"):
+            raise ValueError("type_ must be 'model' or 'matrix'")
+        if type_ == "model":
             return list(self.cell_types_similarity.sort_values(cell_type, ascending=False).index)
-        else:
-            return list(self.cell_types_similarity.T.corr().sort_values(cell_type, ascending=False).index)
+        return list(self.cell_types_similarity.T.corr().sort_values(cell_type, ascending=False).index)
 
-    def check_(self, closest_cell_types, shortest_path):
-        for i in [x for x in shortest_path if x in list(self.network['Cell_type'].unique())]:
-            if i not in list(set(closest_cell_types) & set(list(self.network['Cell_type'].unique()))):
-                return False
-        return True
+    def check_(
+        self,
+        closest_cell_types: list,
+        shortest_path: list,
+    ) -> bool:
+        net_types = set(self.network["Cell_type"].unique())
+        path_cell_types = [x for x in shortest_path if x in net_types]
+        allowed = set(closest_cell_types) & net_types
+        return all(x in allowed for x in path_cell_types)
 
     @staticmethod
-    def write_connections(in_, out_, raw_lists_for_debug, shortest_path_):
-        """
-        Transforms the shortest paths into two lists of In and Out for future network df
-        """
-        raw_lists_for_debug.append(shortest_path_)
-        for j, k in enumerate(shortest_path_):
-            try:
-                out_.append(shortest_path_[j + 1])
-                in_.append(shortest_path_[j])
-            except IndexError:
-                continue
+    def write_connections(
+        in_: list,
+        out: list,
+        raw_lists_for_debug: list,
+        shortest_path_: list,
+    ) -> None:
+        raw_lists_for_debug.append(list(shortest_path_))
+        for j in range(len(shortest_path_) - 1):
+            in_.append(shortest_path_[j])
+            out.append(shortest_path_[j + 1])
 
-    def generate_cell_type_network(self, cluster1, cluster2, number_of_shortest_paths=100,
-                                   minimal_number_of_nodes=3, get_only_direct=False, closest_clusters=10, net=True):
-        """
-        Generate a subnetwork of the nodes and edges between two selected nodes
-        :param cluster1: in cluster
-        :param cluster2: out cluster
-        :param number_of_shortest_paths: how many shortest paths you do consider
-        :param minimal_number_of_nodes: minimal number of the nodes in the subnetwork
-        :param get_only_direct: generates subnetwork with len(shortestpaths)==3
-        :param closest_clusters: how many close cell types you do want to incorporate into the subnetwork
-        :param net: for debugging
-        """
-        in_, out_, raw_lists_for_debug, subnet = [], [], [], pd.DataFrame()
-        graph = nx.from_pandas_edgelist(self.network, 'Gene', 'Cell_type', ['Importance'])
-        for shortest_path_ in [
-            x for x in self.get_shortest_paths(graph,
-                                               cluster1, cluster2, number_of_shortest_paths)
-        ]:
+    def generate_cell_type_network(
+        self,
+        cluster1,
+        cluster2,
+        number_of_shortest_paths: int = 100,
+        minimal_number_of_nodes: int = 3,
+        get_only_direct: bool = False,
+        closest_clusters: int = 10,
+        net: bool = True,
+    ):
+        """Subnetwork between two cell-type nodes via shortest paths and confusion-matrix filtering."""
+        in_, out_, raw_lists_for_debug = [], [], []
+        subnet = pd.DataFrame()
+        graph = nx.from_pandas_edgelist(
+            self.network, source="Gene", target="Cell_type", edge_attr=["Importance"]
+        )
+        for shortest_path_ in self.get_shortest_paths(
+            graph, cluster1, cluster2, number_of_shortest_paths
+        ):
             if get_only_direct:
-                if len(shortest_path_) == minimal_number_of_nodes and self.check_(
-                        self.get_closest_cell_types(cluster2)[:closest_clusters], shortest_path_):
-                    self.write_connections(in_, out_, raw_lists_for_debug, shortest_path_)
-            elif len(shortest_path_) >= minimal_number_of_nodes and self.check_(
-                    self.get_closest_cell_types(cluster2)[:closest_clusters], shortest_path_):
+                ok = len(shortest_path_) == minimal_number_of_nodes and self.check_(
+                    self.get_closest_cell_types(cluster2)[:closest_clusters],
+                    shortest_path_,
+                )
+            else:
+                ok = len(shortest_path_) >= minimal_number_of_nodes and self.check_(
+                    self.get_closest_cell_types(cluster2)[:closest_clusters],
+                    shortest_path_,
+                )
+            if ok:
                 self.write_connections(in_, out_, raw_lists_for_debug, shortest_path_)
-        subnet['in'], subnet['out'] = in_, out_
-        subnet['importance'] = [graph.get_edge_data(row['in'], row['out'])['Importance']
-                                for i, row in subnet.iterrows()]
-        subgraph = nx.from_pandas_edgelist(subnet, 'in', 'out', ['importance'])
-        if net:
-            return subgraph
-        else:
-            return subnet.drop_duplicates()
+        subnet["in"] = in_
+        subnet["out"] = out_
+        if subnet.empty:
+            empty_g = nx.Graph()
+            return empty_g if net else subnet
+        subnet["importance"] = [
+            graph.get_edge_data(row["in"], row["out"])["Importance"]
+            for _, row in subnet.iterrows()
+        ]
+        subgraph = nx.from_pandas_edgelist(subnet, "in", "out", edge_attr=["importance"])
+        return subgraph if net else subnet.drop_duplicates()
 
 
-def draw_net(graph, gene=False, layout='2', font_size=8):
+def draw_net(
+    graph,
+    gene=None,
+    layout: str = "2",
+    font_size: int = 8,
+) -> None:
     """
-    Draw a graph using networkx (with gene labeling)
+    Draw ``graph`` with NetworkX. If ``gene`` is an iterable of nodes, those are labeled;
+    otherwise label nodes with degree ≥ 1 or betweenness ≥ 0.08.
+
+    ``gene`` may be ``False`` for backward compatibility (treated as auto-label mode).
     """
     b = nx.betweenness_centrality(graph)
-    labels = {}
+    labels: dict = {}
+    use_highlight = gene not in (None, False)
+    highlight = set(gene) if use_highlight else None
     for node in graph.nodes():
-        if node:
-            if node in gene:
+        if highlight is not None:
+            if node in highlight:
                 labels[node] = node
         else:
-            if graph.degree[node] >= 1 or b[node] >= 0.08:
+            if graph.degree[node] >= 1 or b.get(node, 0) >= 0.08:
                 labels[node] = node
-    layouts = {'1': nx.spring_layout(graph),
-               '2': nx.kamada_kawai_layout(graph),
-               '3': nx.shell_layout(graph)}
-
-    d = dict(graph.degree)
-    pos = layouts[layout]
-    nx.draw(graph,
-            pos=pos,
-            with_labels=False,
-            nodelist=d.keys(),
-            node_size=1500, alpha=0.7, node_color='lightblue', style='dashed', width=0.5)
-    nx.draw_networkx_labels(graph, pos, labels, font_size=font_size, font_color='black')
+    layouts = {
+        "1": nx.spring_layout(graph),
+        "2": nx.kamada_kawai_layout(graph),
+        "3": nx.shell_layout(graph),
+    }
+    pos = layouts.get(layout, layouts["2"])
+    degrees = dict(graph.degree)
+    nx.draw(
+        graph,
+        pos=pos,
+        with_labels=False,
+        nodelist=list(degrees.keys()),
+        node_size=1500,
+        alpha=0.7,
+        node_color="lightblue",
+        style="dashed",
+        width=0.5,
+    )
+    nx.draw_networkx_labels(graph, pos, labels, font_size=font_size, font_color="black")
     plt.margins(x=0.4, y=0.4)
-    plt.show()
+    _show_or_close(plt.gcf())

--- a/scevonet/programs.py
+++ b/scevonet/programs.py
@@ -1,0 +1,188 @@
+"""Directional interpretation of gene lists and optional gene-set enrichment."""
+
+from __future__ import annotations
+
+import logging
+from typing import Sequence
+
+import numpy as np
+import pandas as pd
+
+logger = logging.getLogger(__name__)
+
+
+def cluster_mean_expression(
+    matrix: pd.DataFrame,
+    labels: Sequence[str] | pd.Series,
+    cluster: str,
+    genes: list[str] | None = None,
+) -> pd.Series:
+    """Mean expression per gene among cells with label ``cluster`` (pseudobulk profile)."""
+    lab = pd.Series(labels, index=matrix.index, dtype=str)
+    mask = lab == str(cluster)
+    if not mask.any():
+        raise ValueError(f"No cells with label {cluster!r}")
+    sub = matrix.loc[mask]
+    if genes is not None:
+        use = [g for g in genes if g in sub.columns]
+        if len(use) < len(genes):
+            missing = set(genes) - set(sub.columns)
+            logger.warning("Genes not in matrix (ignored): %s", sorted(missing)[:10])
+        sub = sub[use]
+    return sub.mean(axis=0)
+
+
+def classify_transition_genes(
+    matrix: pd.DataFrame,
+    labels: Sequence[str] | pd.Series,
+    genes: list[str],
+    cluster_a: str,
+    cluster_b: str,
+    *,
+    eps: float = 1e-6,
+    log2_fc_strong: float = 0.5,
+    rank_high: float = 0.65,
+    rank_low: float = 0.35,
+) -> pd.DataFrame:
+    """
+    Classify candidate genes by **pseudobulk** expression in two cell states.
+
+    This separates **shared** high expression from **gain/loss** along A→B, which
+    tree importance alone does not provide.
+
+    Categories (within the supplied ``genes`` list):
+
+    - **shared_high** — high mean in both A and B (rank among genes ≥ ``rank_high`` in each).
+    - **gain_in_B** — log2(B/A) > ``log2_fc_strong`` and not shared_low.
+    - **loss_from_A** — log2(B/A) < -``log2_fc_strong`` and not shared_low.
+    - **low_both** — low rank in both clusters (≤ ``rank_low``).
+    - **intermediate** — remaining genes.
+
+    Parameters
+    ----------
+    matrix
+        Cells × genes (same units as used for modeling, e.g. log-normalized counts).
+    labels
+        Cell type / cluster per row (aligned with ``matrix``).
+    genes
+        Gene symbols to score (e.g. genes on a shortest-path subnetwork).
+    cluster_a, cluster_b
+        Names of the two states to compare (e.g. source and target cell types).
+    log2_fc_strong
+        |log2 fold-change| above this counts as directional gain/loss.
+    rank_high, rank_low
+        Percentile ranks **within the gene list** for calling high/low in each state.
+    """
+    genes_use = [g for g in genes if g in matrix.columns]
+    if not genes_use:
+        raise ValueError("None of the requested genes are present in the matrix columns.")
+    mu_a = cluster_mean_expression(matrix, labels, cluster_a, genes_use)
+    mu_b = cluster_mean_expression(matrix, labels, cluster_b, genes_use)
+
+    ra = mu_a.rank(pct=True)
+    rb = mu_b.rank(pct=True)
+    lfc = np.log2((mu_b + eps) / (mu_a + eps))
+
+    rows = []
+    for g in genes_use:
+        pa, pb = float(ra[g]), float(rb[g])
+        fc = float(lfc[g])
+        if pa >= rank_high and pb >= rank_high:
+            cat = "shared_high"
+        elif pa <= rank_low and pb <= rank_low:
+            cat = "low_both"
+        elif fc > log2_fc_strong:
+            cat = "gain_in_B"
+        elif fc < -log2_fc_strong:
+            cat = "loss_from_A"
+        else:
+            cat = "intermediate"
+        rows.append(
+            {
+                "gene": g,
+                "mean_in_A": mu_a[g],
+                "mean_in_B": mu_b[g],
+                "log2_fold_change_B_vs_A": fc,
+                "rank_pct_in_A": pa,
+                "rank_pct_in_B": pb,
+                "category": cat,
+            }
+        )
+    return pd.DataFrame(rows).sort_values("log2_fold_change_B_vs_A", ascending=False)
+
+
+def enrich_genes(
+    genes: list[str],
+    *,
+    organism: str = "human",
+    gene_sets: str | list[str] | None = None,
+    outdir: str | None = None,
+    no_plot: bool = True,
+    **kwargs,
+) -> pd.DataFrame:
+    """
+    Run **over-representation analysis** via Enrichr (through ``gseapy``).
+
+    Requires optional dependency: ``pip install 'scevonet[enrichment]'``.
+
+    Parameters
+    ----------
+    genes
+        Gene symbols (HGNC / MGI symbols depending on ``organism``).
+    organism
+        ``human``, ``mouse``, or other Enrichr-supported labels.
+    gene_sets
+        Enrichr library names. Defaults to GO Biological Process + MSigDB Hallmark.
+    outdir
+        If set, write Enrichr tables under this directory (``None`` = no files).
+    **kwargs
+        Passed to ``gseapy.enrichr``.
+
+    Returns
+    -------
+    Combined enrichment table (``gseapy`` results dataframe).
+    """
+    try:
+        import gseapy as gp
+    except ImportError as e:
+        raise ImportError(
+            "enrich_genes requires gseapy. Install with: pip install 'scevonet[enrichment]'"
+        ) from e
+
+    if gene_sets is None:
+        gene_sets = ["GO_Biological_Process_2021", "MSigDB_Hallmark_2020"]
+
+    enr = gp.enrichr(
+        gene_list=list(genes),
+        gene_sets=gene_sets,
+        organism=organism,
+        outdir=outdir,
+        no_plot=no_plot,
+        **kwargs,
+    )
+    return enr.results
+
+
+def enrich_by_cell_type_programs(
+    models_top_features: dict[str, pd.DataFrame],
+    *,
+    top_n: int = 100,
+    organism: str = "human",
+    gene_sets: str | list[str] | None = None,
+    **kwargs,
+) -> dict[str, pd.DataFrame]:
+    """
+    Run enrichment on the top ``top_n`` important genes per cell type (program-level).
+
+    Parameters
+    ----------
+    models_top_features
+        Mapping cell type → feature table with columns ``gene``, ``importance`` (as on :class:`Sample`).
+    """
+    out: dict[str, pd.DataFrame] = {}
+    for ct, feat in models_top_features.items():
+        g = feat["gene"].head(top_n).astype(str).tolist()
+        if not g:
+            continue
+        out[ct] = enrich_genes(g, organism=organism, gene_sets=gene_sets, **kwargs)
+    return out

--- a/scevonet/utils.py
+++ b/scevonet/utils.py
@@ -1,37 +1,41 @@
-import logging
+"""Shared transforms for expression matrices."""
+
+from __future__ import annotations
+
 import numpy as np
-
-logging.basicConfig(level=logging.DEBUG)
-
-
-def sigmoid(x):
-    """
-    Applies sigmoid function
-    """
-    return 1 / (1 + np.exp(-x))
+import pandas as pd
 
 
-def n(df):
-    return (df - df.min()) / (df.max() - df.min())
+def sigmoid(x: pd.DataFrame | np.ndarray) -> pd.DataFrame | np.ndarray:
+    """Sigmoid squashing; clips input for numerical stability."""
+    if isinstance(x, pd.DataFrame):
+        arr = x.to_numpy(dtype=np.float64, copy=True)
+        arr = np.clip(arr, -500.0, 500.0)
+        out = 1.0 / (1.0 + np.exp(-arr))
+        return pd.DataFrame(out, index=x.index, columns=x.columns)
+    x = np.asarray(x, dtype=np.float64)
+    x = np.clip(x, -500.0, 500.0)
+    return 1.0 / (1.0 + np.exp(-x))
 
 
-def update_df(df, top_features):
-    """
-    Updates expression matrix by handling duplicates
-    :param df: expression matrix
-    :param top_features: top important features from the model
-    :return: updated matrix
-    """
-    df = df[top_features]
-    rem, new = {}, []
-    for i in df.columns:
-        if i not in rem:
-            rem[i] = 1
-            new.append(i)
+def update_df(df: pd.DataFrame, top_features: list) -> pd.DataFrame:
+    """Slice to ``top_features`` (unique names, first occurrence) and uniquify duplicate column labels."""
+    seen: set[str] = set()
+    uniq_features: list[str] = []
+    for name in top_features:
+        if name not in seen:
+            seen.add(name)
+            uniq_features.append(name)
+    df = df[uniq_features].copy()
+    counts: dict[str, int] = {}
+    new_cols: list[str] = []
+    for col in df.columns:
+        base = col
+        if base not in counts:
+            counts[base] = 1
+            new_cols.append(base)
         else:
-            new.append(i + '-' + str(rem[i]))
-            rem[i] += 1
-    df.columns = new
+            new_cols.append(f"{base}-{counts[base]}")
+            counts[base] += 1
+    df.columns = new_cols
     return df
-
-

--- a/scevonet/validation.py
+++ b/scevonet/validation.py
@@ -1,0 +1,207 @@
+"""Resampling and negative controls for feature importance and batch robustness."""
+
+from __future__ import annotations
+
+import logging
+from collections import Counter
+from typing import Sequence
+
+import numpy as np
+import pandas as pd
+from sklearn.metrics import roc_auc_score
+
+from scevonet.net import EvoManager, SampleConfig, fit_ovr_model
+
+logger = logging.getLogger(__name__)
+
+
+def bootstrap_importance_stability(
+    matrix: pd.DataFrame,
+    labels: Sequence[str] | pd.Series,
+    cell_type: str,
+    *,
+    config: SampleConfig | None = None,
+    n_bootstrap: int = 20,
+    top_k: int = 100,
+    stability_threshold: float = 0.5,
+    random_seed: int = 0,
+) -> tuple[pd.DataFrame, pd.Series]:
+    """
+    **Bootstrap resampling of cells** — refit the one-vs-rest model for ``cell_type``
+    repeatedly and measure how often each gene appears in the top-``top_k`` by importance.
+
+    Returns
+    -------
+    stability_table
+        Columns: ``gene``, ``frequency`` (proportion of boots in top_k), ``stable``
+        (True if frequency ≥ ``stability_threshold``).
+    observed_ranking
+        Importances from a single fit on the full data (reference ranking).
+
+    Notes
+    -----
+    Computationally heavy (``n_bootstrap`` full LightGBM fits). Reduce ``n_bootstrap``
+    or ``top_k`` for exploration.
+    """
+    cfg = config or SampleConfig()
+    labels_arr = np.asarray(pd.Series(labels).astype(str))
+    n = len(labels_arr)
+    rng = np.random.default_rng(random_seed)
+
+    # Reference fit on full data
+    y_full = pd.Series((labels_arr == cell_type).astype(int), index=matrix.index)
+    ref = fit_ovr_model(matrix, y_full, cfg)
+    ref_genes = ref["features"]["gene"].head(top_k).tolist()
+    ref_imp = ref["features"].set_index("gene")["importance"].reindex(ref_genes)
+
+    counts: Counter[str] = Counter()
+    n_ok = 0
+    for b in range(n_bootstrap):
+        idx = rng.choice(n, size=n, replace=True)
+        matrix_b = matrix.iloc[idx]
+        labels_b = labels_arr[idx]
+        y_b = pd.Series((labels_b == cell_type).astype(int), index=matrix_b.index)
+        # Skip degenerate bootstrap samples
+        if y_b.sum() == 0 or y_b.sum() == len(y_b):
+            continue
+        n_ok += 1
+        boot_cfg = SampleConfig(
+            top_features_limit=cfg.top_features_limit,
+            n_estimators=cfg.n_estimators,
+            test_size=cfg.test_size,
+            random_state=cfg.random_state + b + 1,
+            early_stopping_rounds=cfg.early_stopping_rounds,
+        )
+        out = fit_ovr_model(matrix_b, y_b, boot_cfg)
+        top = set(out["features"]["gene"].head(top_k).astype(str))
+        counts.update(top)
+
+    denom = max(n_ok, 1)
+    freq_rows = []
+    for gene in sorted(counts.keys(), key=lambda g: -counts[g]):
+        freq_rows.append(
+            {
+                "gene": gene,
+                "frequency": counts[gene] / denom,
+                "stable": (counts[gene] / denom) >= stability_threshold,
+            }
+        )
+    stability_df = pd.DataFrame(freq_rows).sort_values("frequency", ascending=False)
+    return stability_df, ref_imp
+
+
+def permutation_importance_null(
+    matrix: pd.DataFrame,
+    labels: Sequence[str] | pd.Series,
+    cell_type: str,
+    *,
+    config: SampleConfig | None = None,
+    n_perm: int = 50,
+    summary_statistic: str = "top10_mean",
+    random_seed: int = 0,
+) -> dict:
+    """
+    **Label permutation null:** shuffle cell-type labels, refit the same OVR model,
+    and build a null distribution of a scalar summary of importance (e.g. mean of top 10).
+
+    Compare the **observed** statistic from the real labels to this null to sanity-check
+    that the classifier is not matching noise.
+
+    Parameters
+    ----------
+    summary_statistic
+        ``top10_mean`` — mean importance of top 10 genes; ``top1`` — max importance.
+
+    Returns
+    -------
+    dict with keys ``observed``, ``null_values``, ``p_value`` (one-sided: how often
+    null ≥ observed; low p suggests structure beyond chance).
+    """
+    cfg = config or SampleConfig()
+    labels_arr = np.asarray(pd.Series(labels).astype(str))
+    rng = np.random.default_rng(random_seed)
+
+    def stat_from_features(feat_df: pd.DataFrame) -> float:
+        imp = feat_df["importance"].values
+        if summary_statistic == "top1":
+            return float(np.nanmax(imp))
+        if summary_statistic == "top10_mean":
+            k = min(10, len(imp))
+            top = np.sort(imp)[-k:]
+            return float(np.mean(top))
+        raise ValueError("summary_statistic must be 'top1' or 'top10_mean'")
+
+    y_real = pd.Series((labels_arr == cell_type).astype(int), index=matrix.index)
+    obs_fit = fit_ovr_model(matrix, y_real, cfg)
+    observed = stat_from_features(obs_fit["features"])
+
+    null_vals: list[float] = []
+    for p in range(n_perm):
+        perm = rng.permutation(labels_arr)
+        y_perm = pd.Series((perm == cell_type).astype(int), index=matrix.index)
+        if y_perm.sum() == 0 or y_perm.sum() == len(y_perm):
+            continue
+        perm_cfg = SampleConfig(
+            top_features_limit=cfg.top_features_limit,
+            n_estimators=cfg.n_estimators,
+            test_size=cfg.test_size,
+            random_state=cfg.random_state + p + 1000,
+            early_stopping_rounds=cfg.early_stopping_rounds,
+        )
+        fit_p = fit_ovr_model(matrix, y_perm, perm_cfg)
+        null_vals.append(stat_from_features(fit_p["features"]))
+
+    if not null_vals:
+        return {"observed": observed, "null_values": [], "p_value": np.nan}
+
+    null_arr = np.asarray(null_vals)
+    p_value = float(np.mean(null_arr >= observed))
+    return {"observed": observed, "null_values": null_vals, "p_value": p_value}
+
+
+def leave_batch_out_auc(
+    matrix: pd.DataFrame,
+    labels: Sequence[str] | pd.Series,
+    batch_labels: Sequence[str] | pd.Series,
+    cell_type: str,
+    *,
+    config: SampleConfig | None = None,
+) -> pd.DataFrame:
+    """
+    **Cross-batch robustness:** for each batch ID, train the OVR model on all other
+    batches and score ROC-AUC on held-out cells from that batch.
+
+    Rows with only one class in the test batch receive NaN AUC.
+
+    Parameters
+    ----------
+    batch_labels
+        Batch / donor / plate ID per cell (aligned with ``matrix`` rows).
+    """
+    cfg = config or SampleConfig()
+    lab = pd.Series(labels, index=matrix.index).astype(str)
+    batches = pd.Series(batch_labels, index=matrix.index).astype(str)
+
+    rows = []
+    for holdout in sorted(batches.unique()):
+        train_mask = batches != holdout
+        test_mask = batches == holdout
+        if train_mask.sum() == 0 or test_mask.sum() == 0:
+            continue
+        m_tr = matrix.loc[train_mask]
+        y_tr = pd.Series((lab.loc[train_mask] == cell_type).astype(int), index=m_tr.index)
+        if y_tr.sum() == 0 or y_tr.sum() == len(y_tr):
+            logger.warning("Skipping batch %s: single class in training portion.", holdout)
+            continue
+        fit = fit_ovr_model(m_tr, y_tr, cfg)
+        feats = fit["features"]["gene"].tolist()
+        m_te = matrix.loc[test_mask]
+        y_te = (lab.loc[test_mask] == cell_type).astype(int).values
+        if len(np.unique(y_te)) < 2:
+            auc = np.nan
+        else:
+            x_prep = EvoManager.prepare_input_df(m_te, feats)
+            pred = fit["model"].predict(x_prep)
+            auc = float(roc_auc_score(y_te, pred))
+        rows.append({"held_out_batch": holdout, "n_test_cells": int(test_mask.sum()), "auc": auc})
+    return pd.DataFrame(rows)

--- a/setup.py
+++ b/setup.py
@@ -1,23 +1,37 @@
 import setuptools
 
-with open("README.md", "r") as fh:
+with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 
-
 setuptools.setup(
-     name='scevonet',
-     version='1.0.0',
-     author="Aleksandr Kotov",
-     author_email="alexander.o.kotov@gmail.com",
-     description="Tool for generation [cell state - gene program] network",
-     long_description=long_description,
-   long_description_content_type="text/markdown",
-     url="https://github.com/Qotov/scEvoNet",
-     packages=setuptools.find_packages(),
-     classifiers=[
-         "Programming Language :: Python :: 3",
-         "License :: OSI Approved :: MIT License",
-         "Operating System :: OS Independent",
-     ],
-    install_requires=['lightgbm>=3.0.0', 'pandas>=0.24', 'networkx>=2.5']
- )
+    name="scevonet",
+    version="2.0.0",
+    author="Aleksandr Kotov",
+    author_email="alexander.o.kotov@gmail.com",
+    description="Cell state and gene program networks from scRNA-seq (LightGBM / cross-dataset)",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    url="https://github.com/Qotov/scEvoNet",
+    packages=setuptools.find_packages(),
+    classifiers=[
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: OS Independent",
+        "Topic :: Scientific/Engineering :: Bio-Informatics",
+    ],
+    python_requires=">=3.9",
+    install_requires=[
+        "lightgbm>=3.0.0",
+        "pandas>=1.3",
+        "numpy>=1.20",
+        "networkx>=2.5",
+        "scipy>=1.7",
+        "scikit-learn>=1.0",
+        "matplotlib>=3.4",
+        "seaborn>=0.11",
+    ],
+)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="scevonet",
-    version="2.0.0",
+    version="2.1.0",
     author="Aleksandr Kotov",
     author_email="alexander.o.kotov@gmail.com",
     description="Cell state and gene program networks from scRNA-seq (LightGBM / cross-dataset)",
@@ -34,4 +34,10 @@ setuptools.setup(
         "matplotlib>=3.4",
         "seaborn>=0.11",
     ],
+    extras_require={
+        "anndata": ["anndata>=0.8"],
+        "enrichment": ["gseapy>=1.0.5"],
+        "dev": ["pytest>=7", "pytest-cov>=4"],
+        "all": ["anndata>=0.8", "gseapy>=1.0.5"],
+    },
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,3 @@
+import matplotlib
+
+matplotlib.use("Agg")

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,0 +1,104 @@
+"""Smoke tests for Sample / EvoManager with tiny synthetic data."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+import importlib
+
+import pytest
+
+from scevonet import EvoManager, Sample, SampleConfig
+from scevonet.net import draw_net
+from scevonet.utils import sigmoid, update_df
+
+
+def _lightgbm_loads() -> bool:
+    try:
+        importlib.import_module("lightgbm")
+        return True
+    except Exception:
+        return False
+
+
+needs_lightgbm = pytest.mark.skipif(
+    not _lightgbm_loads(),
+    reason="LightGBM could not be imported (e.g. missing OpenMP / libomp).",
+)
+
+
+@pytest.fixture
+def tiny_matrix_and_labels():
+    rng = np.random.default_rng(42)
+    n, g = 40, 30
+    X = rng.random((n, g)) * 2.0
+    genes = [f"G{i}" for i in range(g)]
+    df = pd.DataFrame(X, columns=genes)
+    labels = ["A"] * 15 + ["B"] * 15 + ["C"] * 10
+    return df, labels
+
+
+def test_sigmoid_finite():
+    x = pd.DataFrame(np.array([[1000.0, -1000.0]]))
+    y = sigmoid(x)
+    assert np.all(np.isfinite(y.to_numpy()))
+
+
+def test_update_df_makes_duplicate_names_unique():
+    """If the matrix has repeated column labels, output columns become ``name``, ``name-1``, …"""
+    df = pd.DataFrame([[1, 2], [3, 4]], columns=["g0", "g0"])
+    out = update_df(df, ["g0"])
+    assert list(out.columns) == ["g0", "g0-1"]
+
+
+@needs_lightgbm
+def test_sample_and_evomanager(tiny_matrix_and_labels):
+    df, labels = tiny_matrix_and_labels
+    cfg = SampleConfig(
+        top_features_limit=20,
+        n_estimators=30,
+        early_stopping_rounds=5,
+    )
+    s0 = Sample(df, labels, config=cfg)
+    s1 = Sample(df, labels, config=cfg)
+    assert len(s0.models) == 3
+    em = EvoManager(s0, s1, network_top_genes=10)
+    assert em.predictions.keys() == {"0_0", "0_1", "1_0", "1_1"}
+    assert em.cell_types_similarity.shape[0] > 0
+    assert not em.network.empty
+
+
+def test_prepare_input_df_aligns_genes(tiny_matrix_and_labels):
+    df, _ = tiny_matrix_and_labels
+    feats = ["G0", "Gmissing", "G1"]
+    out = EvoManager.prepare_input_df(df, feats)
+    assert list(out.columns) == feats
+    assert np.isnan(out["Gmissing"].iloc[0])
+
+
+def test_draw_net_accepts_false_gene():
+    import matplotlib.pyplot as plt
+    import networkx as nx
+
+    plt.ioff()
+    g = nx.Graph()
+    g.add_edge("a", "b")
+    draw_net(g, gene=False)
+    plt.close("all")
+
+
+@needs_lightgbm
+def test_three_samples_predictions():
+    rng = np.random.default_rng(0)
+    g = 25
+    genes = [f"G{i}" for i in range(g)]
+    df = pd.DataFrame(rng.random((24, g)), columns=genes)
+    labs = ["X"] * 8 + ["Y"] * 8 + ["Z"] * 8
+    cfg = SampleConfig(top_features_limit=15, n_estimators=20, early_stopping_rounds=3)
+    samples = [Sample(df, labs, config=cfg) for _ in range(3)]
+    em = EvoManager(*samples, network_top_genes=5)
+    assert len(em.predictions) == 9
+    # Wide similarity table: one column block per training sample
+    assert em.cell_types_similarity.shape[1] == sum(len(s.models) for s in samples)

--- a/tests/test_programs.py
+++ b/tests/test_programs.py
@@ -1,0 +1,47 @@
+"""Tests for directionality (no LightGBM required)."""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from scevonet.programs import classify_transition_genes, cluster_mean_expression
+
+
+def test_cluster_mean_expression():
+    df = pd.DataFrame(np.random.rand(10, 3), columns=["g1", "g2", "g3"])
+    labels = ["A"] * 5 + ["B"] * 5
+    m = cluster_mean_expression(df, labels, "A")
+    assert len(m) == 3
+    pd.testing.assert_series_equal(m, df.iloc[:5].mean())
+
+
+def test_classify_transition_genes_basic():
+    rng = np.random.default_rng(0)
+    n = 40
+    genes = ["early", "shared", "late", "noise"]
+    X = np.zeros((n, len(genes)))
+    # A: high early, low late
+    X[:15, 0] = 5.0
+    X[:15, 1] = 4.0
+    X[:15, 2] = 0.1
+    X[:15, 3] = rng.random(15)
+    # B: low early, high late + shared
+    X[15:, 0] = 0.1
+    X[15:, 1] = 4.0
+    X[15:, 2] = 5.0
+    X[15:, 3] = rng.random(25)
+    mat = pd.DataFrame(X, columns=genes)
+    labels = ["A"] * 15 + ["B"] * 25
+    out = classify_transition_genes(
+        mat,
+        labels,
+        genes,
+        "A",
+        "B",
+        log2_fc_strong=0.25,
+        rank_high=0.55,
+        rank_low=0.35,
+    )
+    cats = dict(zip(out["gene"], out["category"]))
+    assert cats.get("late") == "gain_in_B"
+    assert cats.get("early") == "loss_from_A"

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,0 +1,60 @@
+"""Validation helpers require LightGBM."""
+
+import importlib
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from scevonet.net import SampleConfig
+from scevonet.validation import leave_batch_out_auc, permutation_importance_null
+
+
+def _lgbm_loads() -> bool:
+    try:
+        importlib.import_module("lightgbm")
+        return True
+    except Exception:
+        return False
+
+
+needs_lightgbm = pytest.mark.skipif(
+    not _lgbm_loads(),
+    reason="LightGBM could not be imported.",
+)
+
+
+@needs_lightgbm
+def test_permutation_importance_null_runs():
+    rng = np.random.default_rng(42)
+    g = 25
+    genes = [f"G{i}" for i in range(g)]
+    X = rng.random((60, g))
+    mat = pd.DataFrame(X, columns=genes)
+    labels = ["T"] * 20 + ["U"] * 20 + ["V"] * 20
+    cfg = SampleConfig(top_features_limit=15, n_estimators=30, early_stopping_rounds=5)
+    out = permutation_importance_null(
+        mat,
+        labels,
+        "T",
+        config=cfg,
+        n_perm=5,
+        random_seed=1,
+    )
+    assert "observed" in out and "p_value" in out
+    assert len(out["null_values"]) >= 1
+
+
+@needs_lightgbm
+def test_leave_batch_out_auc():
+    rng = np.random.default_rng(0)
+    g = 20
+    genes = [f"G{i}" for i in range(g)]
+    X = rng.random((48, g))
+    mat = pd.DataFrame(X, columns=genes)
+    labels = ["P"] * 24 + ["Q"] * 24
+    batches = ["b1"] * 16 + ["b2"] * 16 + ["b3"] * 16
+    cfg = SampleConfig(top_features_limit=12, n_estimators=25, early_stopping_rounds=3)
+    df = leave_batch_out_auc(mat, labels, batches, "P", config=cfg)
+    assert len(df) == 3
+    assert "auc" in df.columns


### PR DESCRIPTION
- Add package __init__ with version 2.0.0 and public exports (SampleConfig, sample_from_adata).
- Replace star imports; add SampleConfig for LGBM/top-K/early stopping.
- Generalize EvoManager to arbitrary sample count (predictions and similarity table); parameterize network gene cap (default 75).
- Lazy-import LightGBM so the package imports without libomp; numpy-based prepare_input_df avoids pandas fragmentation warnings.
- Stabilize sigmoid with clipping; dedupe top_features in update_df.
- Fix draw_net(gene=False) and headless-safe plotting via _show_or_close.
- Declare full runtime deps (sklearn, scipy, matplotlib, seaborn); add pyproject.toml and pytest suite with LightGBM skip when native lib missing.
- Optional scevonet.adata.sample_from_adata for Scanpy workflows.